### PR TITLE
Update ssh-agent.service

### DIFF
--- a/user/ssh-agent.service
+++ b/user/ssh-agent.service
@@ -5,14 +5,12 @@ Before=environment.target
 IgnoreOnIsolate=true
 
 [Service]
-Type=forking
+Type=simple
 Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
-#PIDFile=%t/ssh-agent.pid
-ExecStart=/usr/bin/ssh-agent -a $SSH_AUTH_SOCK
+ExecStart=/usr/bin/ssh-agent -D -a $SSH_AUTH_SOCK
 ExecStartPost=/usr/bin/systemctl --user set-environment SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
-ExecStartPost=/bin/sh -c "ps x -o pid,comm|grep ssh-agent|cut -d' ' -f1 > %t/ssh-agent.pid"
-#ExecStop=/usr/bin/ssh-agent -k
-ExecStopPost=/bin/rm ${SSH_AUTH_SOCK}
+# The line below is not necessary but may be useful to you.
+ExecStartPost=/bin/sh -c "echo $MAINPID > %t/ssh-agent.pid"
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
ssh-agent now has option -D which keeps it from forking, therefore allowing us to use Type=simple. It also allows us to delete any ExecStop*= lines, as the agent will be effectively killed when the unit stops. Additionally, the logic for finding out the main PID is now embedded into systemd, so we can simply check the $MAINPID variable instead of employing pipeline-based logic.
